### PR TITLE
add GNOME gitlab homepage

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -38,7 +38,8 @@ type: docs
 * https://twitter.com/planetgnome
 ### Bugzilla
 * https://bugzilla.gnome.org/
-
+### Gitlab
+* https://gitlab.gnome.org/
 {{< /columns >}}
 
 


### PR DESCRIPTION
add GNOME gitlab homepage
Almost GNOME projects deal with bugs & issues on gitlab homepage.

close #2 