### PR TITLE
Add GitHub Actions for deploying updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    container: klakegg/hugo:latest-ext
+    # Check out latest commit 
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        name: Checkout src repo
+        with:
+          path: src
+          fetch-depth: 0
+          ref: master
+          
+      # Build hugo website with klakegg/actions-hugo@1.0.0 action
+      - name: Build website with hugo
+        working-directory: src
+        run: hugo
+
+      # Checkout destination repository
+      - name: Checkout dest repo
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ secrets.DESTREPO }}
+          path: dest
+          ssh-key: |
+            ${{ secrets.SSH_PRIVATE_KEY }}
+            
+      # Commit and push changes
+      - name: Copy website built from src/public
+        working-directory: dest
+        run: |
+          yes | cp -rf ../src/public/* .
+      # Commit and push changes
+      - name: Commit website updates
+        working-directory: dest
+        env:
+          SRCREPO: ${{ secrets.SRCREPO }}
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Deploy website updates with GitHub Actions: ${SRCREPO}@${GITHUB_SHA}"
+          git push origin master
+  update-submodule:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Check out latest commit (including submodules)
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        name: Checkout src repo
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          ref: master
+
+      # Commit and push changes
+      - name: Commit submodule updates
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+          git submodule update --remote public
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Update 'public' submodule"
+          git push origin master


### PR DESCRIPTION
This GitHub Actions integration builds and deploys website then updates submodule.

아래와 같은 사항을 먼저 설정해야 합니다.

- SSH 키를 생성합니다.
- gnome-korea/gnome-korea.github.io 저장소 설정으로 들어갑니다.
  - Deploy key 에 앞에서 생성한 SSH 키 쌍의 공개키를 등록합니다.
- gnome-korea/gnome-kr-web 저장소 설정의 Secrets 에 다음을 추가합니다.
  - SSH_PRIVATE_KEY: 앞에서 생성한 SSH 키 쌍의 비밀키를 등록합니다.(BEGIN, END 표시 포함)
  - SRCREPO: gnome-korea/gnome-kr-web 로 설정
  - DESTREPO: gnome-korea/gnome-korea.github.io 로 설정

아무래도 저장소가 둘로 나눠져 있어 조금 복잡합니다.

관련 이슈: #5 