### PR TITLE
CI: Install hugo cli manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: klakegg/hugo:latest-ext
     # Check out latest commit 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -20,11 +19,15 @@ jobs:
           path: src
           fetch-depth: 0
           ref: master
+          submodules: recursive
           
       # Build hugo website with klakegg/actions-hugo@1.0.0 action
       - name: Build website with hugo
         working-directory: src
-        run: hugo
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y hugo
+          hugo
 
       # Checkout destination repository
       - name: Checkout dest repo


### PR DESCRIPTION
Since code cannot be checkout with submodules in container mode

서브모듈 체크아웃 안되는 문제 해결을 위해, 컨테이너 모드를 제거하고 hugo cli 를 직접 설치하여 빌드하도록 수정했습니다.

관련 이슈: #5 