### PR TITLE
CI: Install hugo with homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,9 @@ jobs:
       - name: Build website with hugo
         working-directory: src
         run: |
-          sudo apt-get update -q -y
-          sudo apt-get install -q -y hugo
+          yes | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+          yes | brew install hugo
           hugo
-
       # Checkout destination repository
       - name: Checkout dest repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Hugo 문서를 보니 homebrew 통한 설치를 권장하여, homebrew 를 통해 설치하도록 수정했습니다. 
일단 제가 포크 뜬 저장소로 테스트 했을때는 잘 작동합니다.

https://github.com/sukso96100/gnome-kr-web/runs/1049558195?check_suite_focus=true
https://github.com/sukso96100/gnome-korea.github.io/commit/d9ab4e88d92a90f5f12ec391b85b9ea430bc671a

관련 이슈 #5 